### PR TITLE
Widen Metadata values to boolean|number|string to match coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ const log = new Log({
 
 `log.info("foo", { hey: "luring" });` --> 2022-09-24T23:40:39Z [info] foo {"hey":"luring"}
 
+Values may be `string`, `number`, or `boolean`. OTLP attributes are string-only, so `{ count: 5 }`
+is sent as `"5"`; the JSON formatter keeps it native (`5`).
+
 ## Testing
 
 All tests run inside Docker — dependencies are installed in the container too — so a local run is

--- a/index.ts
+++ b/index.ts
@@ -38,8 +38,12 @@ export type LogLevel = keyof typeof LogLevels;
 export type LogShorthand = (msg: string, metadata?: Metadata) => void;
 
 export type Metadata = {
-	[key: string]: string;
+	[key: string]: MetadataValue;
 }
+
+// Primitive values only. String() coerces them for OTLP; the JSON formatter keeps them native.
+// bigint/objects are excluded: JSON.stringify throws on bigint and renders objects as "[object Object]".
+export type MetadataValue = boolean | number | string;
 
 export type OtlpAttribute = {
 	key: string,
@@ -238,7 +242,7 @@ function isFetchError(error: unknown): error is FetchError {
 // service is identified the same way for both — Grafana/Loki reads service.name from here, not the records.
 function buildResourceAttributes(context: Metadata): OtlpAttribute[] {
 	return [
-		{ key: "service.name", value: { stringValue: context["service.name"] || "unnamed-service" } },
+		{ key: "service.name", value: { stringValue: String(context["service.name"] || "unnamed-service") } },
 		{ key: "telemetry.sdk.language", value: { stringValue: "ecmascript" } },
 		{ key: "telemetry.sdk.name", value: { stringValue: "@larvit/log" } },
 		{ key: "telemetry.sdk.version", value: { stringValue: "__version__" } },

--- a/test.ts
+++ b/test.ts
@@ -224,13 +224,14 @@ test("Copy instance", t => {
 });
 
 test("msgJsonFormatter does not mutate input and is undefined-safe", t => {
-	const meta = { user: "abc" };
+	const meta = { count: 5, user: "abc" };
 	const parsed = JSON.parse(msgJsonFormatter({ logLevel: "info", metadata: meta, msg: "hi" }));
 
 	t.strictEqual(parsed.user, "abc", "user metadata preserved");
+	t.strictEqual(parsed.count, 5, "number metadata stays a number in JSON output");
 	t.strictEqual(parsed.msg, "hi", "msg present");
 	t.strictEqual(parsed.logLevel, "info", "logLevel present");
-	t.deepEqual(meta, { user: "abc" }, "caller metadata object is NOT mutated");
+	t.deepEqual(meta, { count: 5, user: "abc" }, "caller metadata object is NOT mutated");
 
 	const parsed2 = JSON.parse(msgJsonFormatter({ logLevel: "error", msg: "boom" }));
 
@@ -365,7 +366,7 @@ test("OLTP simple log with metadata", async t => {
 		spanName: "lur-bert",
 	});
 
-	log.warn("FOo", { bar: "baz", "lökig knasnyckel | typ": "17" });
+	log.warn("FOo", { active: true, bar: "baz", "lökig knasnyckel | typ": 17 });
 	await log.end();
 
 	const logsBody: any = calls.find(call => call.path === "/v1/logs")?.body;
@@ -375,10 +376,12 @@ test("OLTP simple log with metadata", async t => {
 	t.strictEqual(logRecord.body.stringValue, "FOo", "logRecord.body is correct");
 	t.strictEqual(logRecord.severityNumber, 13, "logRecord.severityNumber is correct");
 	t.strictEqual(logRecord.severityText, "WARN", "logRecord.severityText is correct");
-	t.strictEqual(logRecord.attributes[0].key, "bar", "First attribute is bar");
-	t.strictEqual(logRecord.attributes[0].value.stringValue, "baz", "First attribute value is baz");
-	t.strictEqual(logRecord.attributes[1].key, "lökig knasnyckel | typ", "Second attribute key is correct");
-	t.strictEqual(logRecord.attributes[1].value.stringValue, "17", "Second attribute value is \"17\"");
+	t.strictEqual(logRecord.attributes[0].key, "active", "First attribute is active");
+	t.strictEqual(logRecord.attributes[0].value.stringValue, "true", "boolean metadata coerced to \"true\"");
+	t.strictEqual(logRecord.attributes[1].key, "bar", "Second attribute is bar");
+	t.strictEqual(logRecord.attributes[1].value.stringValue, "baz", "Second attribute value is baz");
+	t.strictEqual(logRecord.attributes[2].key, "lökig knasnyckel | typ", "Third attribute key is correct");
+	t.strictEqual(logRecord.attributes[2].value.stringValue, "17", "number metadata coerced to \"17\"");
 
 	// service.name belongs on the log resource (this is what Grafana/Loki reads), not the log record.
 	const logResourceAttrs = logsBody.resourceLogs[0].resource.attributes;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Metadata section in README explaining that metadata values can be strings, numbers, or booleans. Clarifies that OTLP attributes convert all values to strings, while the JSON formatter preserves native types.

* **New Features**
  * Metadata type now supports boolean and number values alongside strings.

* **Tests**
  * Strengthened test coverage for the expanded metadata type system with numeric and boolean value validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->